### PR TITLE
add a check for .metadata.deletionTimestamp to determine whether pods are pending

### DIFF
--- a/autoscale.sh
+++ b/autoscale.sh
@@ -55,7 +55,8 @@ function getPods() {
 
 function countPendingPods() {
   # If hostIP == null then pod is Pending and not scheduled to a node.
-  getPods $1 | jq 'select(.status.hostIP == null) | .metadata.name' | wc -l
+  # If hostIP == null && deletionTimestamp != null, then the pod has hung during deletion (usually because .status.reason == NodeLost)
+  getPods $1 | jq 'select(.status.hostIP == null and .metadata.deletionTimestamp == null) | .metadata.name' | wc -l
 }
 
 function countRunningPods() {


### PR DESCRIPTION
Using .status.hostIP is quite a broad condition, and sometimes selects pods that aren't actually Pending.  

For example, pods on lost nodes may report hostIP == null, but status==Unknown or status==Running.  These pods won't be rescheduled, which can lead to an infinite scale-out loop (as this function returns >0 pods every time it's called, regardless of spare capacity).

Adding a check for deletionTimestamp will ignore these pods when considering whether scale-out is required.